### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ Aluno: Gilson Nogueira - Turma Bruno Rocha 2019.11
 [![codecov](https://codecov.io/gh/engnogueira/webdjango/branch/master/graph/badge.svg)](https://codecov.io/gh/engnogueira/webdjango)
 [![Updates](https://pyup.io/repos/github/engnogueira/webdjango/shield.svg)](https://pyup.io/repos/github/engnogueira/webdjango/)
 [![Python 3](https://pyup.io/repos/github/engnogueira/webdjango/python-3-shield.svg)](https://pyup.io/repos/github/engnogueira/webdjango/)
+[![Run on Repl.it](https://repl.it/badge/github/engnogueira/webdjango)](https://repl.it/github/engnogueira/webdjango)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@engnogueira/webdjango).